### PR TITLE
remove String dispatches for MTK constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ SBML = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "OrdinaryDiffEq"]

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -11,12 +11,6 @@ function ModelingToolkit.ReactionSystem(model::SBML.Model; kwargs...)  # Todo: r
     ReactionSystem(rxs,Catalyst.DEFAULT_IV,species,params; kwargs...)
 end
 
-""" ReactionSystem constructor """
-function ModelingToolkit.ReactionSystem(sbmlfile::String; kwargs...)
-    model = readSBML(sbmlfile,SBML.convert_simplify_math)
-    ReactionSystem(model; kwargs...)
-end
-
 """ ODESystem constructor """
 function ModelingToolkit.ODESystem(model::SBML.Model; kwargs...)
     rs = ReactionSystem(model; kwargs...)
@@ -27,21 +21,9 @@ function ModelingToolkit.ODESystem(model::SBML.Model; kwargs...)
     convert(ODESystem, rs, defaults=defaults)
 end
 
-""" ODESystem constructor """
-function ModelingToolkit.ODESystem(sbmlfile::String; kwargs...)
-    model = readSBML(sbmlfile)
-    ODESystem(model; kwargs...)
-end
-
 """ ODEProblem constructor """
 function ModelingToolkit.ODEProblem(model::SBML.Model,tspan;kwargs...)  # PL: Todo: add u0 and parameters argument
     odesys = ODESystem(model)
-    ODEProblem(odesys, [], tspan; kwargs...)
-end
-
-""" ODEProblem constructor """
-function ModelingToolkit.ODEProblem(sbmlfile::String,tspan;kwargs...)  # PL: Todo: add u0 and parameters argument
-    odesys = ODESystem(sbmlfile)
     ODEProblem(odesys, [], tspan; kwargs...)
 end
 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -21,12 +21,6 @@ function ModelingToolkit.ODESystem(model::SBML.Model; kwargs...)
     convert(ODESystem, rs, defaults=defaults)
 end
 
-""" ODEProblem constructor """
-function ModelingToolkit.ODEProblem(model::SBML.Model,tspan;kwargs...)  # PL: Todo: add u0 and parameters argument
-    odesys = ODESystem(model)
-    ODEProblem(odesys, [], tspan; kwargs...)
-end
-
 """ Check if conversion to ReactionSystem is possible """
 function checksupport(model::SBML.Model)
     for s in values(model.species)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -24,6 +24,7 @@
     @named rs = ReactionSystem(MODEL1)
     isequal(nameof(rs), :rs)
 
+    rs = ReactionSystem(readSBML(sbmlfile))
     # println(Catalyst.get_eqs(rs))
     # println(ModelingToolkit.Reaction[ModelingToolkit.Reaction(c1*k1*2.0*s1*2.0*s2, [s1, s2], [s1s2], [1., 1.], [1.]; use_only_rate=true)])
     @test isequal(Catalyst.get_eqs(rs), ModelingToolkit.Reaction[ModelingToolkit.Reaction(0.25c1*k1*s1*s2, [s1, s2], [s1s2], [1., 1.], [1.]; use_only_rate=true)])

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -78,11 +78,11 @@
     @test_nowarn ODEProblem(odesys, [], [0., 1.], [])
 
     # Test ODEProblem
-    oprob = ODEProblem(MODEL1, [0., 1.])
+    oprob = ODEProblem(ODESystem(MODEL1), [0., 1.])
     sol = solve(oprob, Tsit5())
     @test isapprox(sol.u, [[1.], [2.]])
 
-    @test_nowarn ODEProblem(readSBML(sbmlfile), [0., 1.])
+    @test_nowarn ODEProblem(ODESystem(readSBML(sbmlfile)), [0., 1.])
 
     # Test checksupport
     @test_nowarn SBML.checksupport(MODEL1)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -24,7 +24,6 @@
     @named rs = ReactionSystem(MODEL1)
     isequal(nameof(rs), :rs)
 
-    rs = ReactionSystem(sbmlfile)
     # println(Catalyst.get_eqs(rs))
     # println(ModelingToolkit.Reaction[ModelingToolkit.Reaction(c1*k1*2.0*s1*2.0*s2, [s1, s2], [s1s2], [1., 1.], [1.]; use_only_rate=true)])
     @test isequal(Catalyst.get_eqs(rs), ModelingToolkit.Reaction[ModelingToolkit.Reaction(0.25c1*k1*s1*s2, [s1, s2], [s1s2], [1., 1.], [1.]; use_only_rate=true)])
@@ -34,7 +33,7 @@
     @named rs = ReactionSystem(MODEL1)
     isequal(nameof(rs), :rs)
 
-    rs = ReactionSystem(joinpath("data","reactionsystem_05.xml"))  # Contains reversible reaction
+    rs = ReactionSystem(readSBML(joinpath("data","reactionsystem_05.xml")))  # Contains reversible reaction
     @test isequal(Catalyst.get_eqs(rs),
                   ModelingToolkit.Reaction[
                       ModelingToolkit.Reaction(c1*k1*s1*s2, [s1,s2], [s1s2],
@@ -62,7 +61,7 @@
     isequal(nameof(odesys), :odesys)
     @test_nowarn structural_simplify(odesys)
 
-    odesys = ODESystem(sbmlfile)
+    odesys = ODESystem(readSBML(sbmlfile))
     trueeqs = Equation[Differential(t)(s1) ~ -0.25c1 * k1 * s1 * s2,
                        Differential(t)(s1s2) ~ 0.25c1 * k1 * s1 * s2,
                        Differential(t)(s2) ~ -0.25c1 * k1 * s1 * s2]
@@ -83,7 +82,7 @@
     sol = solve(oprob, Tsit5())
     @test isapprox(sol.u, [[1.], [2.]])
 
-    @test_nowarn ODEProblem(sbmlfile, [0., 1.])
+    @test_nowarn ODEProblem(readSBML(sbmlfile), [0., 1.])
 
     # Test checksupport
     @test_nowarn SBML.checksupport(MODEL1)


### PR DESCRIPTION
@ChrisRackauckas and I talked and these would be considered type piracy, even though there are no methods currently taking String in the main MTK repo, other packages may want to define their own 

@paulflang I am also thinking that we want to remove the direct ODEProblem constructor, per this comment https://github.com/LCSB-BioCore/SBML.jl/pull/40#discussion_r650841927 

I think it makes more sense to just require them to use sth like `ODEProblem(ODESystem(readSBML(filename)))`. 

I haven't implemented that last point yet though