### PR TITLE
return correct variable type/metadata in map_symbolics_ident

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
 authors = ["paulflang", "anandijain"]
-version = "0.1.23"
+version = "0.1.24"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
@@ -12,7 +12,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 [compat]
 Catalyst = "13"
 MathML = "0.1"
-SBML = "1.4"
+SBML = "1.4.4"
 SymbolicUtils = "1"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ using SBMLToolkit, ModelingToolkit, OrdinaryDiffEq
 
 SBMLToolkit.checksupport_file("my_model.xml")
 mdl = readSBML("my_model.xml", doc -> begin
-                   set_level_and_version(3, 2)(doc)
-                   convert_promotelocals_expandfuns(doc)
-               end)
+    set_level_and_version(3, 2)(doc)
+    convert_promotelocals_expandfuns(doc)
+end)
 
 rs = ReactionSystem(mdl)  # If you want to create a reaction system
 odesys = convert(ODESystem, rs)  # Alternatively: ODESystem(mdl)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,27 +7,27 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 DocMeta.setdocmeta!(SBMLToolkit, :DocTestSetup, :(using SBMLToolkit); recursive = true)
 
 makedocs(;
-         modules = [SBMLToolkit],
-         authors = "paulflang, anandijain",
-         sitename = "SBMLToolkit.jl",
-         format = Documenter.HTML(;
-                                  prettyurls = get(ENV, "CI", "false") == "true",
-                                  canonical = "https://docs.sciml.ai/SBMLToolkit/stable/",
-                                  assets = ["assets/favicon.ico"]),
-         clean = true, doctest = false, linkcheck = true,
-         linkcheck_ignore = ["https://www.linkedin.com/in/paul-lang-7b54a81a3/"],
-         strict = [
-             :doctest,
-             :linkcheck,
-             :parse_error,
-             :example_block,
-             # Other available options are
-             # :autodocs_block, :cross_references, :docs_block, :eval_block, :example_block, :footnote, :meta_block, :missing_docs, :setup_block
-         ],
-         pages = [
-             "Home" => "index.md",
-             "API documentation" => "api.md",
-         ])
+    modules = [SBMLToolkit],
+    authors = "paulflang, anandijain",
+    sitename = "SBMLToolkit.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://docs.sciml.ai/SBMLToolkit/stable/",
+        assets = ["assets/favicon.ico"]),
+    clean = true, doctest = false, linkcheck = true,
+    linkcheck_ignore = ["https://www.linkedin.com/in/paul-lang-7b54a81a3/"],
+    strict = [
+        :doctest,
+        :linkcheck,
+        :parse_error,
+        :example_block,
+        # Other available options are
+        # :autodocs_block, :cross_references, :docs_block, :eval_block, :example_block, :footnote, :meta_block, :missing_docs, :setup_block
+    ],
+    pages = [
+        "Home" => "index.md",
+        "API documentation" => "api.md",
+    ])
 
 deploydocs(;
-           repo = "github.com/SciML/SBMLToolkit.jl")
+    repo = "github.com/SciML/SBMLToolkit.jl")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,9 +42,9 @@ using SBMLToolkit, ModelingToolkit, OrdinaryDiffEq
 
 SBMLToolkit.checksupport_file("my_model.xml")
 mdl = readSBML("my_model.xml", doc -> begin
-                   set_level_and_version(3, 2)(doc)
-                   convert_promotelocals_expandfuns(doc)
-               end)
+    set_level_and_version(3, 2)(doc)
+    convert_promotelocals_expandfuns(doc)
+end)
 rs = ReactionSystem(mdl)  # If you want to create a reaction system
 odesys = convert(ODESystem, rs)  # Alternatively: ODESystem(mdl)
 

--- a/src/SBMLToolkit.jl
+++ b/src/SBMLToolkit.jl
@@ -15,7 +15,7 @@ include("utils.jl")
 
 export ReactionSystem, ODESystem
 export readSBML, readSBMLFromString, set_level_and_version, convert_simplify_math,
-       convert_promotelocals_expandfuns
+    convert_promotelocals_expandfuns
 export DefaultImporter, ReactionSystemImporter, ODESystemImporter
 
 end

--- a/src/events.jl
+++ b/src/events.jl
@@ -21,7 +21,7 @@ function get_events(model)  # Todo: implement up or downpass and parameters
             end
             var = create_var(eva.variable, IV; irreducible = true)
             math = substitute(Symbolics.unwrap(interpret_as_num(math, model)),
-                              subsdict)
+                subsdict)
             effect = var ~ math
             push!(mtk_evas, effect)
         end

--- a/src/events.jl
+++ b/src/events.jl
@@ -7,7 +7,7 @@ function get_events(model)  # Todo: implement up or downpass and parameters
     mtk_evs = Pair{Vector{Equation}, Vector{Equation}}[]
     for (_, e) in evs
         trigger = SBML.extensive_kinetic_math(model, e.trigger.math)
-        trigger = Symbolics.unwrap(interpret_as_num(trigger))
+        trigger = Symbolics.unwrap(interpret_as_num(trigger, model))
         lhs, rhs = map(x -> substitute(x, subsdict), trigger.arguments)
         trig = [lhs ~ rhs]
         mtk_evas = Equation[]
@@ -20,7 +20,7 @@ function get_events(model)  # Todo: implement up or downpass and parameters
                 end
             end
             var = create_var(eva.variable, IV; irreducible = true)
-            math = substitute(Symbolics.unwrap(interpret_as_num(math)),
+            math = substitute(Symbolics.unwrap(interpret_as_num(math, model)),
                               subsdict)
             effect = var ~ math
             push!(mtk_evas, effect)

--- a/src/reactions.jl
+++ b/src/reactions.jl
@@ -6,7 +6,7 @@ function get_reactions(model::SBML.Model)
     rxs = Reaction[]
     for reaction in values(model.reactions)
         extensive_math = SBML.extensive_kinetic_math(model, reaction.kinetic_math)
-        symbolic_math = interpret_as_num(extensive_math)
+        symbolic_math = interpret_as_num(extensive_math, model)
         reactant_references = reaction.reactants
         product_references = reaction.products
         if reaction.reversible

--- a/src/reactions.jl
+++ b/src/reactions.jl
@@ -14,9 +14,9 @@ function get_reactions(model::SBML.Model)
             kl_fw, kl_rv = [substitute(x, subsdict) for x in symbolic_math]
             enforce_rate = isequal(kl_rv, 0)
             add_reaction!(rxs, kl_fw, reactant_references, product_references, model;
-                          enforce_rate = enforce_rate)
+                enforce_rate = enforce_rate)
             add_reaction!(rxs, kl_rv, product_references, reactant_references, model;
-                          enforce_rate = enforce_rate)
+                enforce_rate = enforce_rate)
         else
             kl = substitute(symbolic_math, subsdict)  # Todo: use SUBSDICT
             add_reaction!(rxs, kl, reactant_references, product_references, model)
@@ -53,21 +53,21 @@ function get_unidirectional_components(bidirectional_math)
 end
 
 function add_reaction!(rxs::Vector{Reaction},
-                       kl::Num,
-                       reactant_references::Vector{SBML.SpeciesReference},
-                       product_references::Vector{SBML.SpeciesReference},
-                       model::SBML.Model;
-                       enforce_rate = false)
+    kl::Num,
+    reactant_references::Vector{SBML.SpeciesReference},
+    product_references::Vector{SBML.SpeciesReference},
+    model::SBML.Model;
+    enforce_rate = false)
     reactants, products, rstoichvals, pstoichvals = get_reagents(reactant_references,
-                                                                 product_references, model)
+        product_references, model)
     isnothing(reactants) && isnothing(products) && return
     rstoichvals = stoich_convert_to_ints(rstoichvals)
     pstoichvals = stoich_convert_to_ints(pstoichvals)
     kl, our = use_rate(kl, reactants, rstoichvals)
     our = enforce_rate ? true : our
     push!(rxs,
-          Catalyst.Reaction(kl, reactants, products, rstoichvals, pstoichvals;
-                            only_use_rate = our))
+        Catalyst.Reaction(kl, reactants, products, rstoichvals, pstoichvals;
+            only_use_rate = our))
 end
 
 function stoich_convert_to_ints(xs)
@@ -78,8 +78,8 @@ end
 Get reagents
 """
 function get_reagents(reactant_references::Vector{SBML.SpeciesReference},
-                      product_references::Vector{SBML.SpeciesReference},
-                      model::SBML.Model)
+    product_references::Vector{SBML.SpeciesReference},
+    model::SBML.Model)
     reactants = String[]
     products = String[]
     rstoich = Float64[]
@@ -146,7 +146,7 @@ end
 Get kineticLaw for use in MTK.Reaction
 """
 function use_rate(kl::Num, react::Union{Vector{Num}, Nothing},
-                  stoich::Union{Vector{<:Real}, Nothing})
+    stoich::Union{Vector{<:Real}, Nothing})
     rate_const = get_massaction(kl, react, stoich)
     if !isnan(rate_const)
         kl = rate_const
@@ -161,7 +161,7 @@ end
 Get rate constant of mass action kineticLaws
 """
 function get_massaction(kl::Num, reactants::Union{Vector{Num}, Nothing},
-                        stoich::Union{Vector{<:Real}, Nothing})
+    stoich::Union{Vector{<:Real}, Nothing})
     function check_args(x::SymbolicUtils.BasicSymbolic{Real})
         check_args(Val(SymbolicUtils.istree(x)), x)
     end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -5,7 +5,7 @@ function get_rules(model)
     raterules = Equation[]
     for r in model.rules
         if r isa SBML.AlgebraicRule
-            push!(algeqs, 0 ~ interpret_as_num(r.math))
+            push!(algeqs, 0 ~ interpret_as_num(r.math, model))
         elseif r isa SBML.AssignmentRule
             var, ass = get_var_and_assignment(model, r)
             push!(obseqs, var ~ ass)
@@ -31,7 +31,7 @@ function get_var_and_assignment(model, rule)
     if !isnothing(vc)
         math = SBML.MathApply("*", [SBML.MathIdent(vc), math])
     end
-    assignment = interpret_as_num(math)
+    assignment = interpret_as_num(math, model)
     if rule isa SBML.RateRule && haskey(model.species, rule.variable)
         sp = model.species[rule.variable]
         comp = model.compartments[sp.compartment]

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -17,7 +17,7 @@ function get_rules(model)
         end
     end
     algeqs, obseqs, raterules = map(x -> substitute(x, subsdict),
-                                    (algeqs, obseqs, raterules))
+        (algeqs, obseqs, raterules))
     algeqs, obseqs, raterules
 end
 
@@ -52,6 +52,6 @@ function get_volume_correction(model, s_id)
     isnothing(comp.size) && !SBML.seemsdefined(sp.compartment, model) &&
         comp.spatial_dimensions != 0 &&  # remove this line when SBML test suite is fixed
         throw(DomainError(sp.compartment,
-                          "compartment size is insufficiently defined"))
+            "compartment size is insufficiently defined"))
     sp.compartment
 end

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -38,9 +38,9 @@ Create a `ModelingToolkit.ODESystem` from an SBML file, using default import set
 See also [`Model`](@ref) and [`ODESystemImporter`](@ref).
 """
 function SBML.readSBML(sbmlfile::String, ::ODESystemImporter;
-                       include_zero_odes::Bool = true, kwargs...)  # Returns an MTK.ODESystem
+    include_zero_odes::Bool = true, kwargs...)  # Returns an MTK.ODESystem
     convert(ODESystem, readSBML(sbmlfile, ReactionSystemImporter(), kwargs...),
-            include_zero_odes = include_zero_odes)
+        include_zero_odes = include_zero_odes)
 end
 
 """
@@ -69,8 +69,8 @@ function Catalyst.ReactionSystem(model::SBML.Model; kwargs...)  # Todo: requires
             end
         end
         defs[o.lhs] = ModelingToolkit.fixpoint_sub(rhs, defs)
-                                #  ModelingToolkit._merge(defs,
-                                #                         Dict(Catalyst.DEFAULT_IV.val => 0)))
+        #  ModelingToolkit._merge(defs,
+        #                         Dict(Catalyst.DEFAULT_IV.val => 0)))
         push!(obsrules_rearranged, 0 ~ rhs - o.lhs)
     end
     raterules_subs = []
@@ -82,8 +82,8 @@ function Catalyst.ReactionSystem(model::SBML.Model; kwargs...)  # Todo: requires
             end
         end
         defs[o.lhs] = ModelingToolkit.fixpoint_sub(rhs, defs)
-                                #  ModelingToolkit._merge(defs,
-                                #                         Dict(Catalyst.DEFAULT_IV.val => 0)))
+        #  ModelingToolkit._merge(defs,
+        #                         Dict(Catalyst.DEFAULT_IV.val => 0)))
         push!(raterules_subs, rhs ~ o.lhs)
     end
     if haskey(kwargs, :defaults)
@@ -91,10 +91,10 @@ function Catalyst.ReactionSystem(model::SBML.Model; kwargs...)  # Todo: requires
         kwargs = filter(x -> !isequal(first(x), :defaults), kwargs)
     end
     ReactionSystem([rxs..., algrules..., raterules_subs..., obsrules_rearranged...],
-                   IV, first.(u0map), first.(parammap);
-                   defaults = defs, name = gensym(:SBML),
-                   continuous_events = get_events(model),
-                   combinatoric_ratelaws = false, kwargs...)
+        IV, first.(u0map), first.(parammap);
+        defaults = defs, name = gensym(:SBML),
+        continuous_events = get_events(model),
+        combinatoric_ratelaws = false, kwargs...)
 end
 
 """
@@ -105,7 +105,7 @@ Create an `ODESystem` from an `SBML.Model`.
 See also [`ReactionSystem`](@ref).
 """
 function ModelingToolkit.ODESystem(model::SBML.Model; include_zero_odes::Bool = true,
-                                   kwargs...)
+    kwargs...)
     rs = ReactionSystem(model; kwargs...)
     convert(ODESystem, rs; include_zero_odes = include_zero_odes)
 end
@@ -120,12 +120,12 @@ function get_mappings(model::SBML.Model)
             push!(parammap, var => inits[k])
         else
             var = create_var(k, IV;
-                             isbcspecies = has_rule_type(k, model, SBML.RateRule) ||
-                                           has_rule_type(k, model, SBML.AssignmentRule) ||
-                                           (has_rule_type(k, model, SBML.AlgebraicRule) &&
-                                            (all([netstoich(k, r) == 0
-                                                  for r in values(model.reactions)]) ||
-                                             v.boundary_condition == true)))  # To remove species that are otherwise defined
+                isbcspecies = has_rule_type(k, model, SBML.RateRule) ||
+                              has_rule_type(k, model, SBML.AssignmentRule) ||
+                              (has_rule_type(k, model, SBML.AlgebraicRule) &&
+                               (all([netstoich(k, r) == 0
+                                     for r in values(model.reactions)]) ||
+                                v.boundary_condition == true)))  # To remove species that are otherwise defined
             push!(u0map, var => inits[k])
         end
     end
@@ -158,9 +158,9 @@ end
 function netstoich(id, reaction)
     netstoich = 0
     rdict = Dict(getproperty.(reaction.reactants, :species) .=>
-                     getproperty.(reaction.reactants, :stoichiometry))
+        getproperty.(reaction.reactants, :stoichiometry))
     pdict = Dict(getproperty.(reaction.products, :species) .=>
-                     getproperty.(reaction.products, :stoichiometry))
+        getproperty.(reaction.products, :stoichiometry))
     netstoich -= get(rdict, id, 0)
     netstoich += get(pdict, id, 0)
 end

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -133,7 +133,7 @@ function get_mappings(model::SBML.Model)
         elseif v.constant == true && isnothing(v.value)  # Todo: maybe add this branch also to model.compartments
             var = create_param(k)
             val = model.initial_assignments[k]
-            push!(parammap, var => interpret_as_num(val))
+            push!(parammap, var => interpret_as_num(val, model))
         else
             var = create_param(k)
             push!(parammap, var => v.value)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,14 +45,14 @@ function map_symbolics_ident(x::SBML.Math, model::SBML.Model)
     k = x.id
     isspecies = k in keys(model.species) ? true : false
     v = merge(model.species, model.parameters, model.compartments)[k]
-    v.constant && return create_param(k, isconstantspecies=isspecies)
+    v.constant && return Num(create_param(k, isconstantspecies=isspecies))
     isbcspecies = !isspecies &&
                       has_rule_type(k, model, SBML.RateRule) ||
                       has_rule_type(k, model, SBML.AssignmentRule) ||
                       (has_rule_type(k, model, SBML.AlgebraicRule) &&
                           (all([netstoich(k, r) == 0 for r in values(model.reactions)]) ||
                            v.boundary_condition == true))  # To remove species that are otherwise defined
-    return create_var(k, IV; isbcspecies = isbcspecies)
+    return Num(create_var(k, IV; isbcspecies = isbcspecies))
 end
 
 function create_var(x; isbcspecies = false)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,13 +5,6 @@ symbolicsRateOf(x) = D(x)
 const symbolics_mapping = Dict(SBML.default_function_mapping...,
                                "rateOf" => symbolicsRateOf)
 
-# const SUBSDICT = get_substitutions(model)
-
-# map_symbolics_ident(x) = begin
-#     sym = Symbol(x.id)
-#     first(@species $sym)
-# end
-
 function interpret_as_num(x::SBML.Math, model::SBML.Model)
     SBML.interpret_math(x;
                         map_apply = (x::SBML.MathApply, interpret::Function) -> Num(symbolics_mapping[x.fn](interpret.(x.args)...)),
@@ -39,20 +32,6 @@ function get_substitutions(model)
     end
     subsdict
 end
-
-# function map_symbolics_ident(x::SBML.Math, model::SBML.Model)
-#     k = x.id
-#     isspecies = k in keys(model.species) ? true : false
-#     v = merge(model.species, model.parameters, model.compartments)[k]
-#     v.constant && return Num(create_param(k, isconstantspecies=isspecies))
-#     isbcspecies = !isspecies &&
-#                       (has_rule_type(k, model, SBML.RateRule) ||
-#                       has_rule_type(k, model, SBML.AssignmentRule) ||
-#                       (has_rule_type(k, model, SBML.AlgebraicRule) &&
-#                           (all([netstoich(k, r) == 0 for r in values(model.reactions)]) ||
-#                            v.boundary_condition == true)))  # To remove species that are otherwise defined
-#     return Num(create_var(k, IV; isbcspecies = isbcspecies))
-# end
 
 function map_symbolics_ident(x::SBML.Math, model::SBML.Model)
     k = x.id

--- a/test/events.jl
+++ b/test/events.jl
@@ -8,9 +8,9 @@ const IV = Catalyst.DEFAULT_IV
 
 function readmodel(sbml)
     SBMLToolkit.readSBMLFromString(sbml, doc -> begin
-                                       set_level_and_version(3, 2)(doc)
-                                       convert_promotelocals_expandfuns(doc)
-                                   end)
+        set_level_and_version(3, 2)(doc)
+        convert_promotelocals_expandfuns(doc)
+    end)
 end
 
 # Test get_events

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -12,7 +12,13 @@ COMP1 = SBML.Compartment("c1", true, 3, 2.0, "nl", nothing, nothing, nothing, no
                          SBML.CVTerm[])
 SPECIES1 = SBML.Species(name = "s1", compartment = "c1", initial_amount = 1.0,
                         substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = false)  # Todo: Maybe not support units in initial_concentration?
+                        boundary_condition = false, constant = false)
+SPECIES2 = SBML.Species(name = "s2", compartment = "c1", initial_amount = 1.0,
+                        substance_units = "substance", only_substance_units = true,
+                        boundary_condition = false, constant = false)
+SPECIES3 = SBML.Species(name = "s1s2", compartment = "c1", initial_amount = 1.0,
+                        substance_units = "substance", only_substance_units = true,
+                        boundary_condition = false, constant = false)
 KINETICMATH1 = SBML.MathIdent("k1")
 KINETICMATH2 = SBML.MathApply("*", SBML.Math[SBML.MathIdent("k1"), SBML.MathIdent("s2")])
 REACTION1 = SBML.Reaction(products = [
@@ -23,7 +29,9 @@ REACTION1 = SBML.Reaction(products = [
 PARAM1 = SBML.Parameter(name = "k1", value = 1.0, constant = true)
 MODEL1 = SBML.Model(parameters = Dict("k1" => PARAM1),
                     compartments = Dict("c1" => COMP1),
-                    species = Dict("s1" => SPECIES1),
+                    species = Dict("s1" => SPECIES1,
+                                   "s2" => SPECIES2,
+                                   "s1s2" => SPECIES3),
                     reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
 
 # Test get_reactions
@@ -45,12 +53,12 @@ model = SBML.Model(parameters = Dict("k1" => PARAM1),
 
 # Test get_unidirectional_components
 km = SBML.MathApply("-", SBML.Math[KINETICMATH1, SBML.MathIdent("c1")])
-sm = SBMLToolkit.interpret_as_num(km)
+sm = SBMLToolkit.interpret_as_num(km, MODEL1)
 kl = SBMLToolkit.get_unidirectional_components(sm)
 @test isequal(kl, (k1, c1))
 
 km = SBML.MathApply("-", SBML.Math[KINETICMATH1, KINETICMATH2])
-sm = SBMLToolkit.interpret_as_num(km)
+sm = SBMLToolkit.interpret_as_num(km, MODEL1)
 fw, rv = SBMLToolkit.get_unidirectional_components(sm)
 rv = substitute(rv, Dict(SBMLToolkit.create_var("s2") => SBMLToolkit.create_var("s2", IV)))
 @test isequal((fw, rv), (k1, k1 * s2))

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -64,7 +64,7 @@ rv = substitute(rv, Dict(SBMLToolkit.create_var("s2") => SBMLToolkit.create_var(
 @test isequal((fw, rv), (k1, k1 * s2))
 
 km = SBML.MathIdent("s1s2")
-sm1 = SBMLToolkit.interpret_as_num(km)
+sm1 = SBMLToolkit.interpret_as_num(km, MODEL1)
 sm2 = sm - sm1
 @test isequal(SBMLToolkit.get_unidirectional_components(sm2), (sm2, Num(0)))
 @test isequal(SBMLToolkit.get_unidirectional_components(k1), (k1, Num(0)))

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -9,30 +9,30 @@ const IV = Catalyst.DEFAULT_IV
 @species s1(IV), s2(IV), s1s2(IV)
 
 COMP1 = SBML.Compartment("c1", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
-                         SBML.CVTerm[])
+    SBML.CVTerm[])
 SPECIES1 = SBML.Species(name = "s1", compartment = "c1", initial_amount = 1.0,
-                        substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = false)
+    substance_units = "substance", only_substance_units = true,
+    boundary_condition = false, constant = false)
 SPECIES2 = SBML.Species(name = "s2", compartment = "c1", initial_amount = 1.0,
-                        substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = false)
+    substance_units = "substance", only_substance_units = true,
+    boundary_condition = false, constant = false)
 SPECIES3 = SBML.Species(name = "s1s2", compartment = "c1", initial_amount = 1.0,
-                        substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = false)
+    substance_units = "substance", only_substance_units = true,
+    boundary_condition = false, constant = false)
 KINETICMATH1 = SBML.MathIdent("k1")
 KINETICMATH2 = SBML.MathApply("*", SBML.Math[SBML.MathIdent("k1"), SBML.MathIdent("s2")])
 REACTION1 = SBML.Reaction(products = [
-                              SBML.SpeciesReference(species = "s1", stoichiometry = 1),
-                          ],
-                          kinetic_math = KINETICMATH1,
-                          reversible = false)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1),
+    ],
+    kinetic_math = KINETICMATH1,
+    reversible = false)
 PARAM1 = SBML.Parameter(name = "k1", value = 1.0, constant = true)
 MODEL1 = SBML.Model(parameters = Dict("k1" => PARAM1),
-                    compartments = Dict("c1" => COMP1),
-                    species = Dict("s1" => SPECIES1,
-                                   "s2" => SPECIES2,
-                                   "s1s2" => SPECIES3),
-                    reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
+    compartments = Dict("c1" => COMP1),
+    species = Dict("s1" => SPECIES1,
+        "s2" => SPECIES2,
+        "s1s2" => SPECIES3),
+    reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
 
 # Test get_reactions
 reaction = SBMLToolkit.get_reactions(MODEL1)[1]
@@ -41,14 +41,14 @@ truereaction = Catalyst.Reaction(k1, nothing, [s1], nothing, [1])  # Todo: imple
 
 km = SBML.MathTime("x")
 reac = SBML.Reaction(reactants = [
-                         SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
-                     ],
-                     kinetic_math = km,
-                     reversible = false)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
+    ],
+    kinetic_math = km,
+    reversible = false)
 model = SBML.Model(parameters = Dict("k1" => PARAM1),
-                   compartments = Dict("c1" => COMP1),
-                   species = Dict("s1" => SPECIES1),
-                   reactions = Dict("r1" => reac))
+    compartments = Dict("c1" => COMP1),
+    species = Dict("s1" => SPECIES1),
+    reactions = Dict("r1" => reac))
 @test isequal(IV, SBMLToolkit.get_reactions(model)[1].rate)
 
 # Test get_unidirectional_components
@@ -76,16 +76,16 @@ SBMLToolkit.add_reaction!(rxs, k1, SBML.SpeciesReference[], SBML.SpeciesReferenc
 
 rxs = Catalyst.Reaction[]
 SBMLToolkit.add_reaction!(rxs, k1 * s1,
-                          [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
-                          SBML.SpeciesReference[], MODEL1)
+    [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
+    SBML.SpeciesReference[], MODEL1)
 reaction_true = Catalyst.Reaction(k1, [s1], nothing, [1], nothing, only_use_rate = false)
 @test isequal(rxs[1], reaction_true)
 
 rxs = Catalyst.Reaction[]
 SBMLToolkit.add_reaction!(rxs, k1 * s1,
-                          [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
-                          SBML.SpeciesReference[], MODEL1,
-                          enforce_rate = true)
+    [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
+    SBML.SpeciesReference[], MODEL1,
+    enforce_rate = true)
 reaction_true = Catalyst.Reaction(k1, [s1], nothing, [1], nothing, only_use_rate = true)
 @test isequal(rxs, [reaction_true])
 
@@ -99,32 +99,32 @@ t = typeof(SBMLToolkit.stoich_convert_to_ints([1.1, 1])[1])
 
 # Test get_reagents
 @test isequal((nothing, [s1], nothing, [1.0]),
-              SBMLToolkit.get_reagents(REACTION1.reactants, REACTION1.products, MODEL1))
+    SBMLToolkit.get_reagents(REACTION1.reactants, REACTION1.products, MODEL1))
 
 s = SBML.Species(name = "s", compartment = "c1", boundary_condition = true,
-                 initial_amount = 1.0, substance_units = "substance",
-                 only_substance_units = true)
+    initial_amount = 1.0, substance_units = "substance",
+    only_substance_units = true)
 var = SBMLToolkit.create_var("s", IV)
 r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s", stoichiometry = 1.0)],
-                  reversible = false)
+    reversible = false)
 
 m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
 @test isequal(([var], [var], [1.0], [1.0]),
-              SBMLToolkit.get_reagents(r.reactants, r.products, m))
+    SBMLToolkit.get_reagents(r.reactants, r.products, m))
 @test isequal((nothing, nothing, nothing, nothing),
-              SBMLToolkit.get_reagents(r.products, r.reactants, m))
+    SBMLToolkit.get_reagents(r.products, r.reactants, m))
 
 r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s", stoichiometry = 1.0),
-                      SBML.SpeciesReference(species = "s", stoichiometry = 1.0)],
-                  reversible = false)
+        SBML.SpeciesReference(species = "s", stoichiometry = 1.0)],
+    reversible = false)
 m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
 @test isequal(([var], [var], [2.0], [2.0]),
-              SBMLToolkit.get_reagents(r.reactants, r.products, m))
+    SBMLToolkit.get_reagents(r.reactants, r.products, m))
 
 # Test use_rate
 @test isequal(SBMLToolkit.use_rate(k1 * s1, [s1], [1]), (k1, false))  # Case hOSU=true
 @test isequal(SBMLToolkit.use_rate(k1 * s1 * s2 / (c1 + s2), [s1], [1]),
-              (k1 * s1 * s2 / (c1 + s2), true))  # Case Michaelis-Menten kinetics
+    (k1 * s1 * s2 / (c1 + s2), true))  # Case Michaelis-Menten kinetics
 
 # Test get_massaction
 @test isequal(SBMLToolkit.get_massaction(k1 * s1, [s1], [1]), k1)  # Case hOSU=true

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -9,9 +9,9 @@ const IV = Catalyst.DEFAULT_IV
 
 function readmodel(sbml)
     SBMLToolkit.readSBMLFromString(sbml, doc -> begin
-                                       set_level_and_version(3, 2)(doc)
-                                       convert_promotelocals_expandfuns(doc)
-                                   end)
+        set_level_and_version(3, 2)(doc)
+        convert_promotelocals_expandfuns(doc)
+    end)
 end
 
 # Test get_rules
@@ -44,7 +44,7 @@ assignment_true = 7 * compartment
 
 r = SBML.AssignmentRule("S2", SBML.MathVal(1))
 @test_throws ErrorException("Cannot find target for rule with ID `S2`") SBMLToolkit.get_var_and_assignment(m,
-                                                                                                           r)
+    r)
 
 # Test get_volume_correction
 vc = SBMLToolkit.get_volume_correction(m, "notaspecies")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,25 @@
 using SafeTestsets, Test
 
 @safetestset "SBMLToolkit.jl" begin
-    @safetestset "Systems" begin include("systems.jl") end
-    @safetestset "Reactions" begin include("reactions.jl") end
-    @safetestset "Rules" begin include("rules.jl") end
-    @safetestset "Events" begin include("events.jl") end
-    @safetestset "Utils" begin include("utils.jl") end
-    @safetestset "Simulation results" begin include("simresults.jl") end
-    @safetestset "Wuschel" begin include("wuschel.jl") end
+    @safetestset "Systems" begin
+        include("systems.jl")
+    end
+    @safetestset "Reactions" begin
+        include("reactions.jl")
+    end
+    @safetestset "Rules" begin
+        include("rules.jl")
+    end
+    @safetestset "Events" begin
+        include("events.jl")
+    end
+    @safetestset "Utils" begin
+        include("utils.jl")
+    end
+    @safetestset "Simulation results" begin
+        include("simresults.jl")
+    end
+    @safetestset "Wuschel" begin
+        include("wuschel.jl")
+    end
 end

--- a/test/systems.jl
+++ b/test/systems.jl
@@ -9,43 +9,43 @@ const IV = Catalyst.DEFAULT_IV
 @species s1(IV), s2(IV), s1s2(IV)
 
 COMP1 = SBML.Compartment("c1", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
-                         SBML.CVTerm[])
+    SBML.CVTerm[])
 SPECIES1 = SBML.Species(name = "s1", compartment = "c1", initial_amount = 1.0,
-                        substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = false)  # Todo: Maybe not support units in initial_concentration?
+    substance_units = "substance", only_substance_units = true,
+    boundary_condition = false, constant = false)  # Todo: Maybe not support units in initial_concentration?
 SPECIES2 = SBML.Species(name = "s2", compartment = "c1", initial_amount = 1.0,
-                        substance_units = "substance/nl", only_substance_units = false)
+    substance_units = "substance/nl", only_substance_units = false)
 KINETICMATH1 = SBML.MathIdent("k1")
 KINETICMATH2 = SBML.MathApply("*", SBML.Math[SBML.MathIdent("k1"), SBML.MathIdent("s2")])
 KINETICMATH3 = SBML.MathApply("-",
-                              SBML.Math[SBML.MathApply("*",
-                                                       SBML.Math[SBML.MathIdent("k1"),
-                                                                 SBML.MathIdent("s1")]),
-                                        KINETICMATH1])
+    SBML.Math[SBML.MathApply("*",
+            SBML.Math[SBML.MathIdent("k1"),
+                SBML.MathIdent("s1")]),
+        KINETICMATH1])
 REACTION1 = SBML.Reaction(products = [
-                              SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
-                          ],
-                          kinetic_math = KINETICMATH1,
-                          reversible = false)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
+    ],
+    kinetic_math = KINETICMATH1,
+    reversible = false)
 REACTION2 = SBML.Reaction(reactants = [
-                              SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
-                          ],
-                          kinetic_math = KINETICMATH3,
-                          reversible = true)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
+    ],
+    kinetic_math = KINETICMATH3,
+    reversible = true)
 PARAM1 = SBML.Parameter(name = "k1", value = 1.0, constant = true)
 MODEL1 = SBML.Model(parameters = Dict("k1" => PARAM1),
-                    compartments = Dict("c1" => COMP1),
-                    species = Dict("s1" => SPECIES1),
-                    reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
+    compartments = Dict("c1" => COMP1),
+    species = Dict("s1" => SPECIES1),
+    reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
 MODEL2 = SBML.Model(parameters = Dict("k1" => PARAM1),
-                    compartments = Dict("c1" => COMP1),
-                    species = Dict("s1" => SPECIES1),
-                    reactions = Dict("r3" => REACTION2))
+    compartments = Dict("c1" => COMP1),
+    species = Dict("s1" => SPECIES1),
+    reactions = Dict("r3" => REACTION2))
 
 # Test ReactionSystem constructor
 rs = ReactionSystem(MODEL1)
 @test isequal(Catalyst.get_eqs(rs),
-              Catalyst.Reaction[Catalyst.Reaction(k1, nothing, [s1], nothing, [1.0])])
+    Catalyst.Reaction[Catalyst.Reaction(k1, nothing, [s1], nothing, [1.0])])
 @test isequal(Catalyst.get_iv(rs), IV)
 @test isequal(Catalyst.get_states(rs), [s1])
 @test isequal(Catalyst.get_ps(rs), [k1, c1])
@@ -54,8 +54,8 @@ isequal(nameof(rs), :rs)
 
 rs = ReactionSystem(readSBML(sbmlfile))
 @test isequal(Catalyst.get_eqs(rs),
-              Catalyst.Reaction[Catalyst.Reaction(k1 / c1, [s1, s2], [s1s2], [1.0, 1.0],
-                                                  [1.0])])
+    Catalyst.Reaction[Catalyst.Reaction(k1 / c1, [s1, s2], [s1s2], [1.0, 1.0],
+        [1.0])])
 @test isequal(Catalyst.get_iv(rs), IV)
 @test isequal(Catalyst.get_states(rs), [s1, s1s2, s2])
 @test isequal(Catalyst.get_ps(rs), [k1, c1])
@@ -64,10 +64,10 @@ isequal(nameof(rs), :rs)
 
 rs = ReactionSystem(MODEL2)  # Contains reversible reaction
 @test isequal(Catalyst.get_eqs(rs),
-              Catalyst.Reaction[Catalyst.Reaction(k1, [s1], nothing,
-                                                  [1], nothing),
-                                Catalyst.Reaction(k1, nothing, [s1],
-                                                  nothing, [1])])
+    Catalyst.Reaction[Catalyst.Reaction(k1, [s1], nothing,
+            [1], nothing),
+        Catalyst.Reaction(k1, nothing, [s1],
+            nothing, [1])])
 @test isequal(Catalyst.get_iv(rs), IV)
 @test isequal(Catalyst.get_states(rs), [s1])
 @test isequal(Catalyst.get_ps(rs), [k1, c1])
@@ -92,8 +92,8 @@ isequal(nameof(odesys), :odesys)
 odesys = ODESystem(readSBML(sbmlfile))
 m = readSBML(sbmlfile)
 trueeqs = Equation[Differential(IV)(s1) ~ -(k1 * s1 * s2) / c1,
-                   Differential(IV)(s1s2) ~ (k1 * s1 * s2) / c1,
-                   Differential(IV)(s2) ~ -(k1 * s1 * s2) / c1]
+    Differential(IV)(s1s2) ~ (k1 * s1 * s2) / c1,
+    Differential(IV)(s2) ~ -(k1 * s1 * s2) / c1]
 @test isequal(Catalyst.get_eqs(odesys), trueeqs)
 @test isequal(Catalyst.get_iv(odesys), IV)
 @test isequal(Catalyst.get_states(odesys), [s1, s1s2, s2])
@@ -122,7 +122,7 @@ parammap_true = [k1 => 1.0, c1 => 2.0]
 
 p = SBML.Parameter(name = "k2", value = 1.0, constant = false)
 m = SBML.Model(parameters = Dict("k2" => p),
-               rules = SBML.Rule[SBML.RateRule("k2", KINETICMATH2)])
+    rules = SBML.Rule[SBML.RateRule("k2", KINETICMATH2)])
 u0map, parammap = SBMLToolkit.get_mappings(m)
 u0map_true = [SBMLToolkit.create_var("k2", IV; isbcspecies = true) => 1.0]
 @test isequal(u0map, u0map_true)
@@ -131,34 +131,34 @@ u0map_true = [SBMLToolkit.create_var("k2", IV; isbcspecies = true) => 1.0]
 p = SBML.Parameter(name = "k2", value = nothing, constant = true)
 ia = Dict("k2" => KINETICMATH1)
 m = SBML.Model(parameters = Dict("k1" => PARAM1, "k2" => p),
-               initial_assignments = ia)
+    initial_assignments = ia)
 u0map, parammap = SBMLToolkit.get_mappings(m)
 parammap_true = [k1 => 1.0, SBMLToolkit.create_var("k2") => k1]
 @test isequal(parammap, parammap_true)
 
 m = SBML.Model(species = Dict("s2" => SPECIES2),
-               rules = SBML.Rule[SBML.AlgebraicRule(KINETICMATH2)])
+    rules = SBML.Rule[SBML.AlgebraicRule(KINETICMATH2)])
 u0map, parammap = SBMLToolkit.get_mappings(m)
 Catalyst.isbc(first(u0map[1]))
 
 # Test get_netstoich
 r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
-                  kinetic_math = KINETICMATH1,
-                  reversible = false)
+    kinetic_math = KINETICMATH1,
+    reversible = false)
 ns = SBMLToolkit.netstoich("s1", r)
 @test isequal(ns, -1)
 
 r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
-                  products = [SBML.SpeciesReference(species = "s1", stoichiometry = 2.0)],
-                  kinetic_math = KINETICMATH1,
-                  reversible = false)
+    products = [SBML.SpeciesReference(species = "s1", stoichiometry = 2.0)],
+    kinetic_math = KINETICMATH1,
+    reversible = false)
 ns = SBMLToolkit.netstoich("s1", r)
 @test isequal(ns, 1)
 
 # Test checksupport_file
 @test_nowarn SBMLToolkit.checksupport_file(sbmlfile)
 @test_throws ErrorException SBMLToolkit.checksupport_file(joinpath("data",
-                                                                   "unsupported.sbml"))
+    "unsupported.sbml"))
 
 # Test checksupport_string
 @test_nowarn SBMLToolkit.checksupport_string("all good <reaction")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,26 +4,26 @@ using Test
 
 function readmodel(sbml)
     SBMLToolkit.readSBMLFromString(sbml, doc -> begin
-                                       set_level_and_version(3, 2)(doc)
-                                       convert_promotelocals_expandfuns(doc)
-                                   end)
+        set_level_and_version(3, 2)(doc)
+        convert_promotelocals_expandfuns(doc)
+    end)
 end
 
 COMP1 = SBML.Compartment("C", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
-                         SBML.CVTerm[])
+    SBML.CVTerm[])
 SPECIES1 = SBML.Species(name = "B", compartment = "C", initial_amount = 1.0,
-                        substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = false)  # Todo: Maybe not support units in initial_concentration?
+    substance_units = "substance", only_substance_units = true,
+    boundary_condition = false, constant = false)  # Todo: Maybe not support units in initial_concentration?
 PARAM1 = SBML.Parameter(name = "D", value = 1.0, constant = true)
 SPECIES2 = SBML.Species(name = "Bc", compartment = "C", initial_amount = 1.0,
-                        substance_units = "substance", only_substance_units = true,
-                        boundary_condition = false, constant = true)  # Todo: Maybe not support units in initial_concentration?
+    substance_units = "substance", only_substance_units = true,
+    boundary_condition = false, constant = true)  # Todo: Maybe not support units in initial_concentration?
 PARAM2 = SBML.Parameter(name = "Dv", value = 1.0, constant = false)
 RULE1 = SBML.AssignmentRule("Dv", SBML.MathIdent("B"))
 MODEL1 = SBML.Model(parameters = Dict("D" => PARAM1, "Dv" => PARAM2),
-                    compartments = Dict("C" => COMP1),
-                    species = Dict("B" => SPECIES1, "Bc" => SPECIES2),
-                    rules = [RULE1]) 
+    compartments = Dict("C" => COMP1),
+    species = Dict("B" => SPECIES1, "Bc" => SPECIES2),
+    rules = [RULE1])
 
 const IV = Catalyst.DEFAULT_IV
 @species s1(IV)
@@ -42,19 +42,20 @@ sym = SBMLToolkit.map_symbolics_ident(SBML.MathIdent("B"), MODEL1)
 @parameters C D Bc
 
 test = SBML.MathApply("*",
-                      SBML.Math[SBML.MathApply("+",
-                                               SBML.Math[SBML.MathApply("*",
-                                                                        SBML.Math[SBML.MathAvogadro("A"),
-                                                                                  SBML.MathIdent("B")]),
-                                                         SBML.MathApply("-",
-                                                                        SBML.Math[SBML.MathApply("*",
-                                                                                                 SBML.Math[SBML.MathIdent("C"),
-                                                                                                           SBML.MathIdent("D"),
-                                                                                                           SBML.MathIdent("Dv"),
-                                                                                                           SBML.MathIdent("Bc")])])]),
-                                SBML.MathTime("Time")])
+    SBML.Math[SBML.MathApply("+",
+            SBML.Math[SBML.MathApply("*",
+                    SBML.Math[SBML.MathAvogadro("A"),
+                        SBML.MathIdent("B")]),
+                SBML.MathApply("-",
+                    SBML.Math[SBML.MathApply("*",
+                        SBML.Math[SBML.MathIdent("C"),
+                            SBML.MathIdent("D"),
+                            SBML.MathIdent("Dv"),
+                            SBML.MathIdent("Bc")])])]),
+        SBML.MathTime("Time")])
 
-@test isequal(SBMLToolkit.interpret_as_num(test, MODEL1), IV * (6.02214076e23 * B - C * D * Dv * Bc))
+@test isequal(SBMLToolkit.interpret_as_num(test, MODEL1),
+    IV * (6.02214076e23 * B - C * D * Dv * Bc))
 
 # Test get_substitutions
 sbml, _, _ = SBMLToolkitTestSuite.read_case("00001")
@@ -63,9 +64,9 @@ subsdict = SBMLToolkit.get_substitutions(m)
 @parameters k1, compartment
 @species S1(IV), S2(IV)
 subsdict_true = Dict(Num(Symbolics.variable(:S1; T = Real)) => S1,
-                     Num(Symbolics.variable(:S2; T = Real)) => S2,
-                     Num(Symbolics.variable(:k1; T = Real)) => k1,
-                     Num(Symbolics.variable(:compartment; T = Real)) => compartment)
+    Num(Symbolics.variable(:S2; T = Real)) => S2,
+    Num(Symbolics.variable(:k1; T = Real)) => k1,
+    Num(Symbolics.variable(:compartment; T = Real)) => compartment)
 @test isequal(subsdict, subsdict_true)
 
 # Test create_var

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -19,9 +19,11 @@ SPECIES2 = SBML.Species(name = "Bc", compartment = "C", initial_amount = 1.0,
                         substance_units = "substance", only_substance_units = true,
                         boundary_condition = false, constant = true)  # Todo: Maybe not support units in initial_concentration?
 PARAM2 = SBML.Parameter(name = "Dv", value = 1.0, constant = false)
+RULE1 = SBML.AssignmentRule("Dv", SBML.MathIdent("B"))
 MODEL1 = SBML.Model(parameters = Dict("D" => PARAM1, "Dv" => PARAM2),
                     compartments = Dict("C" => COMP1),
-                    species = Dict("B" => SPECIES1, "Bc" => SPECIES2)) 
+                    species = Dict("B" => SPECIES1, "Bc" => SPECIES2),
+                    rules = [RULE1]) 
 
 const IV = Catalyst.DEFAULT_IV
 @species s1(IV)
@@ -36,8 +38,7 @@ sym = SBMLToolkit.map_symbolics_ident(SBML.MathIdent("B"), MODEL1)
 @test isequal(sym, B)
 
 # Test interpret_as_num
-@species B(IV)
-@variables Dv(IV)
+@species B(IV) Dv(IV)
 @parameters C D Bc
 
 test = SBML.MathApply("*",

--- a/test/wuschel.jl
+++ b/test/wuschel.jl
@@ -8,8 +8,9 @@ using Test
 sbml_url = "https://www.ebi.ac.uk/biomodels/model/download/MODEL1112100000.2?filename=MODEL1112100000_url.xml"
 sbml = String(take!(Downloads.download(sbml_url, IOBuffer())))
 m = readSBMLFromString(sbml, doc -> begin
-                       # set_level_and_version(3, 2)(doc) # fails on wuschel
-                       convert_promotelocals_expandfuns(doc) end)
+    # set_level_and_version(3, 2)(doc) # fails on wuschel
+    convert_promotelocals_expandfuns(doc)
+end)
 sys = ODESystem(m)
 @test length(equations(sys)) == 1012
 @test length(states(sys)) == 1012


### PR DESCRIPTION
If an initialAssignment contains a species instead of a parameter, this species needs to be a function of `t` such that it can be substituted with the defaults.