### PR TITLE
omit conversion to mass action for stoichiometries > 100 to avoid StackOverflow in simplify_fractions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
 authors = ["paulflang", "anandijain"]
-version = "0.1.25"
+version = "0.1.26"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"

--- a/src/reactions.jl
+++ b/src/reactions.jl
@@ -19,6 +19,7 @@ function get_reactions(model::SBML.Model)
                 enforce_rate = enforce_rate)
         else
             kl = substitute(symbolic_math, subsdict)  # Todo: use SUBSDICT
+            println(reaction)
             add_reaction!(rxs, kl, reactant_references, product_references, model)
         end
     end
@@ -61,7 +62,9 @@ function add_reaction!(rxs::Vector{Reaction},
     reactants, products, rstoichvals, pstoichvals = get_reagents(reactant_references,
         product_references, model)
     isnothing(reactants) && isnothing(products) && return
+    println("rstoichvals: $rstoichvals")
     rstoichvals = stoich_convert_to_ints(rstoichvals)
+    println("rstoichvals: $rstoichvals")
     pstoichvals = stoich_convert_to_ints(pstoichvals)
     kl, our = use_rate(kl, reactants, rstoichvals)
     our = enforce_rate ? true : our
@@ -183,7 +186,17 @@ function get_massaction(kl::Num, reactants::Union{Vector{Num}, Nothing},
         rate_const = kl
     elseif isnothing(reactants) | isnothing(stoich)
         throw(ErrorException("`reactants` and `stoich` are inconsistent: `reactants` are $(reactants) and `stoich` is $(stoich)."))
+    elseif max(stoich...) > 100  # simplify_fractions might StackOverflow
+        rate_const = kl
     else
+        println("kl")
+        println(kl)
+        println("reactants")
+        println(reactants)
+        println(stoich)
+        println(*((.^(reactants, stoich))...))
+        println("fraction")
+        println(kl / *((.^(reactants, stoich))...))
         rate_const = SymbolicUtils.simplify_fractions(kl / *((.^(reactants, stoich))...))
     end
 

--- a/src/reactions.jl
+++ b/src/reactions.jl
@@ -92,7 +92,7 @@ function get_reagents(reactant_references::Vector{SBML.SpeciesReference},
         sn = rr.species
         stoich = rr.stoichiometry
         if isnothing(stoich)
-            @warn "Stoichiometries of SpeciesReferences are not defined. Setting to 1." maxlog=1
+            @warn "SBML SpeciesReferences does not contain stoichiometries. Assuming stoichiometry of 1." maxlog=1
             stoich = 1.0
         end
         iszero(stoich) && @error("Stoichiometry of $sn must be non-zero")

--- a/src/reactions.jl
+++ b/src/reactions.jl
@@ -19,7 +19,6 @@ function get_reactions(model::SBML.Model)
                 enforce_rate = enforce_rate)
         else
             kl = substitute(symbolic_math, subsdict)  # Todo: use SUBSDICT
-            println(reaction)
             add_reaction!(rxs, kl, reactant_references, product_references, model)
         end
     end
@@ -62,9 +61,7 @@ function add_reaction!(rxs::Vector{Reaction},
     reactants, products, rstoichvals, pstoichvals = get_reagents(reactant_references,
         product_references, model)
     isnothing(reactants) && isnothing(products) && return
-    println("rstoichvals: $rstoichvals")
     rstoichvals = stoich_convert_to_ints(rstoichvals)
-    println("rstoichvals: $rstoichvals")
     pstoichvals = stoich_convert_to_ints(pstoichvals)
     kl, our = use_rate(kl, reactants, rstoichvals)
     our = enforce_rate ? true : our
@@ -189,14 +186,6 @@ function get_massaction(kl::Num, reactants::Union{Vector{Num}, Nothing},
     elseif max(stoich...) > 100  # simplify_fractions might StackOverflow
         rate_const = kl
     else
-        println("kl")
-        println(kl)
-        println("reactants")
-        println(reactants)
-        println(stoich)
-        println(*((.^(reactants, stoich))...))
-        println("fraction")
-        println(kl / *((.^(reactants, stoich))...))
         rate_const = SymbolicUtils.simplify_fractions(kl / *((.^(reactants, stoich))...))
     end
 

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -135,7 +135,7 @@ m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
 @test isequal(SBMLToolkit.get_massaction(k1 + c1, nothing, nothing), k1 + c1)  # Case zero order kineticLaw
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * s2 / (c1 + s2), [s1], [1]))  # Case Michaelis-Menten kinetics
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * IV, [s1], [1]))  # Case kineticLaw with time
-@test isequal(SBMLToolkit.get_massaction(k1 * (s1 + s1), [s1], [101]), k1 * (s1 + s1))  # Case no simplification performed due to large rstoich
+@test isnan(SBMLToolkit.get_massaction(k1 * s1, [s1], [101]))  # Case no simplification performed due to large rstoich
 
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * s2, [s1], [1]))
 @test isnan(SBMLToolkit.get_massaction(k1 + c1, [s1], [1]))

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -135,6 +135,7 @@ m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
 @test isequal(SBMLToolkit.get_massaction(k1 + c1, nothing, nothing), k1 + c1)  # Case zero order kineticLaw
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * s2 / (c1 + s2), [s1], [1]))  # Case Michaelis-Menten kinetics
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * IV, [s1], [1]))  # Case kineticLaw with time
+@test isequal(SBMLToolkit.get_massaction(k1 * (s1 + s1), [s1], [101]), k1 * (s1 + s1))  # Case no simplication performed due to large rstoich
 
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * s2, [s1], [1]))
 @test isnan(SBMLToolkit.get_massaction(k1 + c1, [s1], [1]))

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -135,7 +135,7 @@ m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
 @test isequal(SBMLToolkit.get_massaction(k1 + c1, nothing, nothing), k1 + c1)  # Case zero order kineticLaw
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * s2 / (c1 + s2), [s1], [1]))  # Case Michaelis-Menten kinetics
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * IV, [s1], [1]))  # Case kineticLaw with time
-@test isequal(SBMLToolkit.get_massaction(k1 * (s1 + s1), [s1], [101]), k1 * (s1 + s1))  # Case no simplication performed due to large rstoich
+@test isequal(SBMLToolkit.get_massaction(k1 * (s1 + s1), [s1], [101]), k1 * (s1 + s1))  # Case no simplification performed due to large rstoich
 
 @test isnan(SBMLToolkit.get_massaction(k1 * s1 * s2, [s1], [1]))
 @test isnan(SBMLToolkit.get_massaction(k1 + c1, [s1], [1]))


### PR DESCRIPTION
## Checklist

- [ x] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context

This is to fix #160 . The model in question contains stoichiometries in excess to 1e4, which causes StackOverflow in SymbolicUtils.simplify fractions. The fix here is to no longer attempt to recover mass action kinetics from generic SBML rate laws whenever reactant stoichiometry is >100. This circumvents the need for calling simplify_fractions.
