### PR TITLE
Fix(CI): Update branch references to main

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -3,7 +3,7 @@ name: format-check
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'release-'
     tags: '*'
   pull_request:


### PR DESCRIPTION
This PR updates the CI workflow files to reference the main branch instead of master, ensuring that the CI runs on the correct default branch.

Created by RooCode, an AI tool.