### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-format_markdown = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -3,40 +3,17 @@ name: format-check
 on:
   push:
     branches:
+      - 'master'
       - 'main'
       - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  runic:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
-
       - uses: actions/checkout@v4
-      - name: Install JuliaFormatter and format
-        # This will use the latest version by default but you can set the version like so:
-        #
-        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
-        run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
-      - name: Format check
-        run: |
-          julia -e '
-          out = Cmd(`git diff`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "Some files have not been formatted !!!"
-              write(stdout, out)
-              exit(1)
-          end'
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,11 +16,14 @@ makedocs(;
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",
         canonical = "https://docs.sciml.ai/SBMLToolkit/stable/",
-        assets = ["assets/favicon.ico"]),
+        assets = ["assets/favicon.ico"]
+    ),
     pages = [
         "Home" => "index.md",
-        "API documentation" => "api.md"
-    ])
+        "API documentation" => "api.md",
+    ]
+)
 
 deploydocs(;
-    repo = "github.com/SciML/SBMLToolkit.jl")
+    repo = "github.com/SciML/SBMLToolkit.jl"
+)

--- a/src/SBMLToolkit.jl
+++ b/src/SBMLToolkit.jl
@@ -15,7 +15,7 @@ include("utils.jl")
 
 export ReactionSystem, ODESystem
 export readSBML, readSBMLFromString, set_level_and_version, convert_simplify_math,
-       convert_promotelocals_expandfuns, checksupport_file
+    convert_promotelocals_expandfuns, checksupport_file
 export DefaultImporter, ReactionSystemImporter, ODESystemImporter
 
 end

--- a/src/events.jl
+++ b/src/events.jl
@@ -20,8 +20,10 @@ function get_events(model)  # Todo: implement up or downpass and parameters
                 end
             end
             var = create_var(eva.variable, IV; irreducible = true)
-            math = substitute(Symbolics.unwrap(interpret_as_num(math, model)),
-                subsdict)
+            math = substitute(
+                Symbolics.unwrap(interpret_as_num(math, model)),
+                subsdict
+            )
             effect = var ~ math
             push!(mtk_evas, effect)
         end
@@ -29,5 +31,5 @@ function get_events(model)  # Todo: implement up or downpass and parameters
     end
     !isempty(evs) &&
         @warn "SBMLToolkit currently fires events regardless of uppass or downpass trigger."
-    isempty(mtk_evs) ? nothing : mtk_evs
+    return isempty(mtk_evs) ? nothing : mtk_evs
 end

--- a/test/events.jl
+++ b/test/events.jl
@@ -7,10 +7,12 @@ const IV = default_t()
 @species S1(IV) S2(IV)
 
 function readmodel(sbml)
-    SBMLToolkit.readSBMLFromString(sbml, doc -> begin
-        set_level_and_version(3, 2)(doc)
-        convert_promotelocals_expandfuns(doc)
-    end)
+    return SBMLToolkit.readSBMLFromString(
+        sbml, doc -> begin
+            set_level_and_version(3, 2)(doc)
+            convert_promotelocals_expandfuns(doc)
+        end
+    )
 end
 
 # Test get_events
@@ -24,9 +26,11 @@ events = SBMLToolkit.get_events(m)
 events_true = [[S1 / compartment ~ 0.1] => [S1 ~ compartment]]
 @test isequal(events, events_true)
 
-sbml, _, _ = SBMLToolkitTestSuite.read_case("00041")  # multiple events 
+sbml, _, _ = SBMLToolkitTestSuite.read_case("00041")  # multiple events
 m = readmodel(sbml)
 events = SBMLToolkit.get_events(m)
-events_true = [[S1 / compartment ~ 0.1] => [S1 ~ compartment],
-    [S2 / compartment ~ 0.5] => [S2 ~ 0]]
+events_true = [
+    [S1 / compartment ~ 0.1] => [S1 ~ compartment],
+    [S2 / compartment ~ 0.5] => [S2 ~ 0],
+]
 @test isequal(events, events_true)

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -3,8 +3,10 @@ using SBMLToolkit, Aqua
     Aqua.find_persistent_tasks_deps(SBMLToolkit)
     Aqua.test_ambiguities(SBMLToolkit, recursive = false)
     Aqua.test_deps_compat(SBMLToolkit)
-    Aqua.test_piracies(SBMLToolkit,
-        treat_as_own = [SBMLToolkit.SBML.Model])
+    Aqua.test_piracies(
+        SBMLToolkit,
+        treat_as_own = [SBMLToolkit.SBML.Model]
+    )
     Aqua.test_project_extras(SBMLToolkit)
     Aqua.test_stale_deps(SBMLToolkit)
     Aqua.test_unbound_args(SBMLToolkit)

--- a/test/reactions.jl
+++ b/test/reactions.jl
@@ -8,32 +8,45 @@ const IV = default_t()
 @parameters k1, c1
 @species s1(IV), s2(IV), s1s2(IV)
 
-COMP1 = SBML.Compartment("c1", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
-    SBML.CVTerm[])
-SPECIES1 = SBML.Species(name = "s1", compartment = "c1", initial_amount = 1.0,
+COMP1 = SBML.Compartment(
+    "c1", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
+    SBML.CVTerm[]
+)
+SPECIES1 = SBML.Species(
+    name = "s1", compartment = "c1", initial_amount = 1.0,
     substance_units = "substance", only_substance_units = true,
-    boundary_condition = false, constant = false)
-SPECIES2 = SBML.Species(name = "s2", compartment = "c1", initial_amount = 1.0,
+    boundary_condition = false, constant = false
+)
+SPECIES2 = SBML.Species(
+    name = "s2", compartment = "c1", initial_amount = 1.0,
     substance_units = "substance", only_substance_units = true,
-    boundary_condition = false, constant = false)
-SPECIES3 = SBML.Species(name = "s1s2", compartment = "c1", initial_amount = 1.0,
+    boundary_condition = false, constant = false
+)
+SPECIES3 = SBML.Species(
+    name = "s1s2", compartment = "c1", initial_amount = 1.0,
     substance_units = "substance", only_substance_units = true,
-    boundary_condition = false, constant = false)
+    boundary_condition = false, constant = false
+)
 KINETICMATH1 = SBML.MathIdent("k1")
 KINETICMATH2 = SBML.MathApply("*", SBML.Math[SBML.MathIdent("k1"), SBML.MathIdent("s2")])
 REACTION1 = SBML.Reaction(
     products = [
-        SBML.SpeciesReference(species = "s1", stoichiometry = 1)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1),
     ],
     kinetic_math = KINETICMATH1,
-    reversible = false)
+    reversible = false
+)
 PARAM1 = SBML.Parameter(name = "k1", value = 1.0, constant = true)
-MODEL1 = SBML.Model(parameters = Dict("k1" => PARAM1),
+MODEL1 = SBML.Model(
+    parameters = Dict("k1" => PARAM1),
     compartments = Dict("c1" => COMP1),
-    species = Dict("s1" => SPECIES1,
+    species = Dict(
+        "s1" => SPECIES1,
         "s2" => SPECIES2,
-        "s1s2" => SPECIES3),
-    reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
+        "s1s2" => SPECIES3
+    ),
+    reactions = Dict("r1" => REACTION1)
+)  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
 
 # Test get_reactions
 reaction = SBMLToolkit.get_reactions(MODEL1)[1]
@@ -43,14 +56,17 @@ truereaction = Catalyst.Reaction(k1, nothing, [s1], nothing, [1])  # Todo: imple
 km = SBML.MathTime("x")
 reac = SBML.Reaction(
     reactants = [
-        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
     ],
     kinetic_math = km,
-    reversible = false)
-model = SBML.Model(parameters = Dict("k1" => PARAM1),
+    reversible = false
+)
+model = SBML.Model(
+    parameters = Dict("k1" => PARAM1),
     compartments = Dict("c1" => COMP1),
     species = Dict("s1" => SPECIES1),
-    reactions = Dict("r1" => reac))
+    reactions = Dict("r1" => reac)
+)
 @test isequal(IV, SBMLToolkit.get_reactions(model)[1].rate)
 
 # Test get_unidirectional_components
@@ -77,17 +93,21 @@ SBMLToolkit.add_reaction!(rxs, k1, SBML.SpeciesReference[], SBML.SpeciesReferenc
 @test isequal(rxs, Catalyst.Reaction[])
 
 rxs = Catalyst.Reaction[]
-SBMLToolkit.add_reaction!(rxs, k1 * s1,
+SBMLToolkit.add_reaction!(
+    rxs, k1 * s1,
     [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
-    SBML.SpeciesReference[], MODEL1)
+    SBML.SpeciesReference[], MODEL1
+)
 reaction_true = Catalyst.Reaction(k1, [s1], nothing, [1], nothing, only_use_rate = false)
 @test isequal(rxs[1], reaction_true)
 
 rxs = Catalyst.Reaction[]
-SBMLToolkit.add_reaction!(rxs, k1 * s1,
+SBMLToolkit.add_reaction!(
+    rxs, k1 * s1,
     [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
     SBML.SpeciesReference[], MODEL1,
-    enforce_rate = true)
+    enforce_rate = true
+)
 reaction_true = Catalyst.Reaction(k1, [s1], nothing, [1], nothing, only_use_rate = true)
 @test isequal(rxs, [reaction_true])
 
@@ -100,34 +120,51 @@ t = typeof(SBMLToolkit.stoich_convert_to_ints([1.1, 1])[1])
 @test isequal(t, Float64)
 
 # Test get_reagents
-@test isequal((nothing, [s1], nothing, [1.0]),
-    SBMLToolkit.get_reagents(REACTION1.reactants, REACTION1.products, MODEL1))
+@test isequal(
+    (nothing, [s1], nothing, [1.0]),
+    SBMLToolkit.get_reagents(REACTION1.reactants, REACTION1.products, MODEL1)
+)
 
-s = SBML.Species(name = "s", compartment = "c1", boundary_condition = true,
+s = SBML.Species(
+    name = "s", compartment = "c1", boundary_condition = true,
     initial_amount = 1.0, substance_units = "substance",
-    only_substance_units = true)
+    only_substance_units = true
+)
 var = SBMLToolkit.create_var("s", IV)
-r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s", stoichiometry = 1.0)],
-    reversible = false)
+r = SBML.Reaction(
+    reactants = [SBML.SpeciesReference(species = "s", stoichiometry = 1.0)],
+    reversible = false
+)
 
 m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
-@test isequal(([var], [var], [1.0], [1.0]),
-    SBMLToolkit.get_reagents(r.reactants, r.products, m))
-@test isequal((nothing, nothing, nothing, nothing),
-    SBMLToolkit.get_reagents(r.products, r.reactants, m))
+@test isequal(
+    ([var], [var], [1.0], [1.0]),
+    SBMLToolkit.get_reagents(r.reactants, r.products, m)
+)
+@test isequal(
+    (nothing, nothing, nothing, nothing),
+    SBMLToolkit.get_reagents(r.products, r.reactants, m)
+)
 
 r = SBML.Reaction(
-    reactants = [SBML.SpeciesReference(species = "s", stoichiometry = 1.0),
-        SBML.SpeciesReference(species = "s", stoichiometry = 1.0)],
-    reversible = false)
+    reactants = [
+        SBML.SpeciesReference(species = "s", stoichiometry = 1.0),
+        SBML.SpeciesReference(species = "s", stoichiometry = 1.0),
+    ],
+    reversible = false
+)
 m = SBML.Model(species = Dict("s" => s), reactions = Dict("r1" => r))
-@test isequal(([var], [var], [2.0], [2.0]),
-    SBMLToolkit.get_reagents(r.reactants, r.products, m))
+@test isequal(
+    ([var], [var], [2.0], [2.0]),
+    SBMLToolkit.get_reagents(r.reactants, r.products, m)
+)
 
 # Test use_rate
 @test isequal(SBMLToolkit.use_rate(k1 * s1, [s1], [1]), (k1, false))  # Case hOSU=true
-@test isequal(SBMLToolkit.use_rate(k1 * s1 * s2 / (c1 + s2), [s1], [1]),
-    (k1 * s1 * s2 / (c1 + s2), true))  # Case Michaelis-Menten kinetics
+@test isequal(
+    SBMLToolkit.use_rate(k1 * s1 * s2 / (c1 + s2), [s1], [1]),
+    (k1 * s1 * s2 / (c1 + s2), true)
+)  # Case Michaelis-Menten kinetics
 
 # Test get_massaction
 @test isequal(SBMLToolkit.get_massaction(k1 * s1, [s1], [1]), k1)  # Case hOSU=true

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -8,10 +8,12 @@ const IV = default_t()
 @species S1(IV), S2(IV)
 
 function readmodel(sbml)
-    SBMLToolkit.readSBMLFromString(sbml, doc -> begin
-        set_level_and_version(3, 2)(doc)
-        convert_promotelocals_expandfuns(doc)
-    end)
+    return SBMLToolkit.readSBMLFromString(
+        sbml, doc -> begin
+            set_level_and_version(3, 2)(doc)
+            convert_promotelocals_expandfuns(doc)
+        end
+    )
 end
 
 # Test get_rules
@@ -45,7 +47,8 @@ assignment_true = 7 * compartment
 r = SBML.AssignmentRule("S2", SBML.MathVal(1))
 @test_throws ErrorException("Cannot find target for rule with ID `S2`") SBMLToolkit.get_var_and_assignment(
     m,
-    r)
+    r
+)
 
 # Test get_volume_correction
 vc = SBMLToolkit.get_volume_correction(m, "notaspecies")

--- a/test/simresults.jl
+++ b/test/simresults.jl
@@ -1,7 +1,8 @@
 using SBMLToolkitTestSuite
 using Test
 
-const case_ids = [7,  # boundary_condition
+const case_ids = [
+    7,  # boundary_condition
     22,  # non-integer stoichiometry
     23,  # species with constant=boundaryCondition="true"
     41,  # events
@@ -9,7 +10,7 @@ const case_ids = [7,  # boundary_condition
     170,  # Model using parameters and rules only
     325,  # One reactions and two rate rules with four species in a 2D compartment
     679,  # Initial value calculated by assignmentRule in compartment of non-unit size    # 1208, # Non-hOSU species with rateRule in variable compartment -> require MTK fix.
-    944  # Non-constant parameter as target of event_assignment
+    944,  # Non-constant parameter as target of event_assignment
 ]
 
 const logdir = joinpath(@__DIR__, "logs")

--- a/test/systems.jl
+++ b/test/systems.jl
@@ -8,46 +8,68 @@ const IV = default_t()
 @parameters k1, c1
 @species s1(IV), s2(IV), s1s2(IV)
 
-COMP1 = SBML.Compartment("c1", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
-    SBML.CVTerm[])
-SPECIES1 = SBML.Species(name = "s1", compartment = "c1", initial_amount = 1.0,
+COMP1 = SBML.Compartment(
+    "c1", true, 3, 2.0, "nl", nothing, nothing, nothing, nothing,
+    SBML.CVTerm[]
+)
+SPECIES1 = SBML.Species(
+    name = "s1", compartment = "c1", initial_amount = 1.0,
     substance_units = "substance", only_substance_units = true,
-    boundary_condition = false, constant = false)  # Todo: Maybe not support units in initial_concentration?
-SPECIES2 = SBML.Species(name = "s2", compartment = "c1", initial_amount = 1.0,
-    substance_units = "substance/nl", only_substance_units = false)
+    boundary_condition = false, constant = false
+)  # Todo: Maybe not support units in initial_concentration?
+SPECIES2 = SBML.Species(
+    name = "s2", compartment = "c1", initial_amount = 1.0,
+    substance_units = "substance/nl", only_substance_units = false
+)
 KINETICMATH1 = SBML.MathIdent("k1")
 KINETICMATH2 = SBML.MathApply("*", SBML.Math[SBML.MathIdent("k1"), SBML.MathIdent("s2")])
-KINETICMATH3 = SBML.MathApply("-",
-    SBML.Math[SBML.MathApply("*",
-        SBML.Math[SBML.MathIdent("k1"),
-        SBML.MathIdent("s1")]),
-    KINETICMATH1])
+KINETICMATH3 = SBML.MathApply(
+    "-",
+    SBML.Math[
+        SBML.MathApply(
+            "*",
+            SBML.Math[
+                SBML.MathIdent("k1"),
+                SBML.MathIdent("s1"),
+            ]
+        ),
+        KINETICMATH1,
+    ]
+)
 REACTION1 = SBML.Reaction(
     products = [
-        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
     ],
     kinetic_math = KINETICMATH1,
-    reversible = false)
+    reversible = false
+)
 REACTION2 = SBML.Reaction(
     reactants = [
-        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)
+        SBML.SpeciesReference(species = "s1", stoichiometry = 1.0),
     ],
     kinetic_math = KINETICMATH3,
-    reversible = true)
+    reversible = true
+)
 PARAM1 = SBML.Parameter(name = "k1", value = 1.0, constant = true)
-MODEL1 = SBML.Model(parameters = Dict("k1" => PARAM1),
+MODEL1 = SBML.Model(
+    parameters = Dict("k1" => PARAM1),
     compartments = Dict("c1" => COMP1),
     species = Dict("s1" => SPECIES1),
-    reactions = Dict("r1" => REACTION1))  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
-MODEL2 = SBML.Model(parameters = Dict("k1" => PARAM1),
+    reactions = Dict("r1" => REACTION1)
+)  # PL: For instance in the compartments dict, we may want to enforce that key and compartment.name are identical
+MODEL2 = SBML.Model(
+    parameters = Dict("k1" => PARAM1),
     compartments = Dict("c1" => COMP1),
     species = Dict("s1" => SPECIES1),
-    reactions = Dict("r3" => REACTION2))
+    reactions = Dict("r3" => REACTION2)
+)
 
 # Test ReactionSystem constructor
 rs = ReactionSystem(MODEL1)
-@test isequal(Catalyst.get_eqs(rs),
-    Catalyst.Reaction[Catalyst.Reaction(k1, nothing, [s1], nothing, [1.0])])
+@test isequal(
+    Catalyst.get_eqs(rs),
+    Catalyst.Reaction[Catalyst.Reaction(k1, nothing, [s1], nothing, [1.0])]
+)
 @test isequal(Catalyst.get_iv(rs), IV)
 @test isequal(Catalyst.get_species(rs), [s1])
 @test issetequal(Catalyst.get_ps(rs), [k1, c1])
@@ -55,9 +77,15 @@ rs = ReactionSystem(MODEL1)
 isequal(nameof(rs), :rs)
 
 rs = ReactionSystem(readSBML(sbmlfile))
-@test isequal(Catalyst.get_eqs(rs),
-    Catalyst.Reaction[Catalyst.Reaction(k1 / c1, [s1, s2], [s1s2], [1.0, 1.0],
-        [1.0])])
+@test isequal(
+    Catalyst.get_eqs(rs),
+    Catalyst.Reaction[
+        Catalyst.Reaction(
+            k1 / c1, [s1, s2], [s1s2], [1.0, 1.0],
+            [1.0]
+        ),
+    ]
+)
 @test isequal(Catalyst.get_iv(rs), IV)
 @test isequal(Catalyst.get_species(rs), [s1, s1s2, s2])
 @test issetequal(Catalyst.get_ps(rs), [k1, c1])
@@ -65,11 +93,19 @@ rs = ReactionSystem(readSBML(sbmlfile))
 isequal(nameof(rs), :rs)
 
 rs = ReactionSystem(MODEL2)  # Contains reversible reaction
-@test isequal(Catalyst.get_eqs(rs),
-    Catalyst.Reaction[Catalyst.Reaction(k1, [s1], nothing,
-            [1], nothing),
-        Catalyst.Reaction(k1, nothing, [s1],
-            nothing, [1])])
+@test isequal(
+    Catalyst.get_eqs(rs),
+    Catalyst.Reaction[
+        Catalyst.Reaction(
+            k1, [s1], nothing,
+            [1], nothing
+        ),
+        Catalyst.Reaction(
+            k1, nothing, [s1],
+            nothing, [1]
+        ),
+    ]
+)
 @test isequal(Catalyst.get_iv(rs), IV)
 @test isequal(Catalyst.get_species(rs), [s1])
 @test issetequal(Catalyst.get_ps(rs), [k1, c1])
@@ -94,9 +130,11 @@ isequal(nameof(odesys), :odesys)
 
 odesys = ODESystem(readSBML(sbmlfile))
 m = readSBML(sbmlfile)
-trueeqs = Equation[default_time_deriv()(s1) ~ -((k1 * s1 * s2) / c1),
-default_time_deriv()(s1s2) ~ (k1 * s1 * s2) / c1,
-default_time_deriv()(s2) ~ -((k1 * s1 * s2) / c1)]
+trueeqs = Equation[
+    default_time_deriv()(s1) ~ -((k1 * s1 * s2) / c1),
+    default_time_deriv()(s1s2) ~ (k1 * s1 * s2) / c1,
+    default_time_deriv()(s2) ~ -((k1 * s1 * s2) / c1),
+]
 @test isequal(Catalyst.get_eqs(odesys), trueeqs)
 @test isequal(Catalyst.get_iv(odesys), IV)
 @test isequal(Catalyst.get_unknowns(odesys), [s1, s1s2, s2])
@@ -127,8 +165,10 @@ initial_assignment_map_true = Pair[]
 @test isequal(initial_assignment_map, initial_assignment_map_true)
 
 p = SBML.Parameter(name = "k2", value = 1.0, constant = false)
-m = SBML.Model(parameters = Dict("k2" => p),
-    rules = SBML.Rule[SBML.RateRule("k2", KINETICMATH2)])
+m = SBML.Model(
+    parameters = Dict("k2" => p),
+    rules = SBML.Rule[SBML.RateRule("k2", KINETICMATH2)]
+)
 u0map, parammap, initial_assignment_map = SBMLToolkit.get_mappings(m)
 u0map_true = [SBMLToolkit.create_var("k2", IV; isbcspecies = true) => 1.0]
 @test isequal(u0map, u0map_true)
@@ -136,37 +176,49 @@ u0map_true = [SBMLToolkit.create_var("k2", IV; isbcspecies = true) => 1.0]
 
 p = SBML.Parameter(name = "k2", value = nothing, constant = true)
 ia = Dict("k2" => KINETICMATH1)
-m = SBML.Model(parameters = Dict("k1" => PARAM1, "k2" => p),
-    initial_assignments = ia)
+m = SBML.Model(
+    parameters = Dict("k1" => PARAM1, "k2" => p),
+    initial_assignments = ia
+)
 u0map, parammap, initial_assignment_map = SBMLToolkit.get_mappings(m)
 parammap_true = [k1 => 1.0, SBMLToolkit.create_var("k2") => k1]
 initial_assignment_map_true = [SBMLToolkit.create_var("k2") => k1]
 @test isequal(parammap, parammap_true)
 @test isequal(initial_assignment_map, initial_assignment_map_true)
 
-m = SBML.Model(species = Dict("s2" => SPECIES2),
-    rules = SBML.Rule[SBML.AlgebraicRule(KINETICMATH2)])
+m = SBML.Model(
+    species = Dict("s2" => SPECIES2),
+    rules = SBML.Rule[SBML.AlgebraicRule(KINETICMATH2)]
+)
 u0map, parammap, initial_assignment_map = SBMLToolkit.get_mappings(m)
 Catalyst.isbc(first(u0map[1]))
 
 # Test get_netstoich
-r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
+r = SBML.Reaction(
+    reactants = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
     kinetic_math = KINETICMATH1,
-    reversible = false)
+    reversible = false
+)
 ns = SBMLToolkit.netstoich("s1", r)
 @test isequal(ns, -1)
 
-r = SBML.Reaction(reactants = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
+r = SBML.Reaction(
+    reactants = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
     products = [SBML.SpeciesReference(species = "s1", stoichiometry = 2.0)],
     kinetic_math = KINETICMATH1,
-    reversible = false)
+    reversible = false
+)
 ns = SBMLToolkit.netstoich("s1", r)
 @test isequal(ns, 1)
 
 # Test checksupport_file
 @test_nowarn SBMLToolkit.checksupport_file(sbmlfile)
-@test_throws ErrorException SBMLToolkit.checksupport_file(joinpath("data",
-    "unsupported.sbml"))
+@test_throws ErrorException SBMLToolkit.checksupport_file(
+    joinpath(
+        "data",
+        "unsupported.sbml"
+    )
+)
 
 # Test checksupport_string
 @test_nowarn SBMLToolkit.checksupport_string("all good <reaction")

--- a/test/wuschel.jl
+++ b/test/wuschel.jl
@@ -7,10 +7,12 @@ using Test
 
 sbml_url = "https://www.ebi.ac.uk/biomodels/model/download/MODEL1112100000.2?filename=MODEL1112100000_url.xml"
 sbml = String(take!(Downloads.download(sbml_url, IOBuffer())))
-m = readSBMLFromString(sbml, doc -> begin
-    # set_level_and_version(3, 2)(doc) # fails on wuschel
-    convert_promotelocals_expandfuns(doc)
-end)
+m = readSBMLFromString(
+    sbml, doc -> begin
+        # set_level_and_version(3, 2)(doc) # fails on wuschel
+        convert_promotelocals_expandfuns(doc)
+    end
+)
 sys = ODESystem(m)
 @test length(equations(sys)) == 1012
 @test length(unknowns(sys)) == 1012


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)